### PR TITLE
feat: refactor vagrant.yml to better define hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,12 +12,33 @@ else
 end
 settings = config_file
 
+# Helper functions
+def destructure_host_dict(dict)
+  dict.values_at("ip", "hostname", "cpus", "memory")
+end
+
+
+domain = settings["domain"]
+
+# define groups and hostvars for ansible provisionner
+ansible_configuration = settings["hosts"].each_with_object({"hostvars": {}, "groups": Hash.new {|hash, key| hash[key] = []}}) do |host, configuration|
+  ip, hostname, cpus, memory = destructure_host_dict(host)
+  configuration[:hostvars][hostname] = {
+    :ip     => ip,
+    :domain => domain,
+  }
+  host.fetch("groups", []).each do |group|
+    configuration[:groups][group] << host["hostname"]
+  end # end group
+end # end configuration
+
+
 Vagrant.configure("2") do |config|
   config.vm.box = settings["box"]
   config.vm.synced_folder "./", "/vagrant", type: "rsync", rsync__auto: true, rsync__exclude: ['files/*.tar.gz', 'files/*.tgz', 'collections/', 'group_vars/', 'logs/', 'roles/']
 
-  settings["hosts"].each do |host_data|
-    ip, hostname, domain, cpus, memory = *host_data
+  settings["hosts"].each do |host|
+    ip, hostname, cpus, memory = destructure_host_dict(host)
     config.vm.define hostname, autostart: true do |cfg|
       cfg.vm.hostname = hostname
       cfg.vm.network "private_network", ip: ip
@@ -31,17 +52,12 @@ Vagrant.configure("2") do |config|
         libvirt.cpus = cpus
         libvirt.memory = memory
       end # end provider libvirt
-
     end # end define
   end # end settings
 
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "#{vagrantfile_dir}/ping.yml"
-    ansible.host_vars = settings["hosts"].each_with_object ({}) do |(ip, hostname, domain, cpus, memory), dict|
-      dict[hostname] = {
-        :ip     => ip,
-        :domain => domain,
-      }
-    end # end host_vars
+    ansible.host_vars = ansible_configuration[:hostvars]
+    ansible.groups = ansible_configuration[:groups]
   end # end provision
 end

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -2,13 +2,53 @@
 # Run "vagrant reload" when box is modified
 box: centos/7
 
+# network domain
+domain: tdp
+
 # Cluster VMs' ip, hostname, domain, cpus and memory (generates VM deployment config)
 hosts:
-  # |------ip-------|-hostname-|domain|cpus|memory|
-  - ["192.168.56.10", edge-01, tdp, 2, 2048]
-  - ["192.168.56.11", master-01, tdp, 3, 3072]
-  - ["192.168.56.12", master-02, tdp, 3, 3072]
-  - ["192.168.56.13", master-03, tdp, 3, 3072]
-  - ["192.168.56.14", worker-01, tdp, 2, 2048]
-  - ["192.168.56.15", worker-02, tdp, 2, 2048]
-  - ["192.168.56.16", worker-03, tdp, 2, 2048]
+  - cpus: 2
+    groups:
+      - edge
+    hostname: edge-01
+    ip: 192.168.56.10
+    memory: 2048
+  - cpus: 3
+    groups:
+      - master
+      - master1
+    hostname: master-01
+    ip: 192.168.56.11
+    memory: 3072
+  - cpus: 3
+    groups:
+      - master
+      - master2
+    hostname: master-02
+    ip: 192.168.56.12
+    memory: 3072
+  - cpus: 3
+    groups:
+      - master
+      - master3
+    hostname: master-03
+    ip: 192.168.56.13
+    memory: 3072
+  - cpus: 2
+    groups:
+      - worker
+    hostname: worker-01
+    ip: 192.168.56.14
+    memory: 2048
+  - cpus: 2
+    groups:
+      - worker
+    hostname: worker-02
+    ip: 192.168.56.15
+    memory: 2048
+  - cpus: 2
+    groups:
+      - worker
+    hostname: worker-03
+    ip: 192.168.56.16
+    memory: 2048


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #6

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

In this PR:
##### The hosts list is now a list of dicts

New format:
```yaml
hosts:
  - hostname: host1
    ip: ...
  - hostname: host2
    ip: ...
  - hostname: host3
    ip: ...
  - hostname: host4
    ip: ...
```

The host dictionary must contain the following keys:
* cpus
* hostname
* ip
* memory

Optional keys are:
* groups <-- list of groups to add the host to

##### Make the `domain` key a cluster-wide configuration key
Domain has been removed as a host configuration key, as there is currently no need to define the domain on a per host basis.

##### Ansible inventory change

The groups are defined inside the inventory generated by vagrant:

```diff
+ [edge]
+ edge-01
+ 
+ [master]
+ master-01
+ master-02
+ master-03
+ 
+ [master1]
+ master-01
+
+ [master2]
+ master-02
+
+ [master3]
+ master-03
+
+ [worker]
+ worker-01
+ worker-02
+ worker-03
```

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


