### PR TITLE
fix: set ping strategy to linear

### DIFF
--- a/ping.yml
+++ b/ping.yml
@@ -2,6 +2,7 @@
 - hosts: all
   gather_facts: no
   become: no
+  strategy: linear
   tasks:
     - name: ping
       ping:


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes no issue

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->
Vagrant provisioning fails when using mitogen_linear strategy.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


