### PR TITLE
fix: remove hostname from hosts

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -2,8 +2,8 @@
 - hosts: all
   become: yes
   tasks:
-    - name: Configure /etc/hosts to configure domain
+    - name: Remove hostname configuration on loopback interface
       lineinfile:
         path: /etc/hosts
-        regexp: '^127\.0\.1\.1 {{ ansible_hostname }} {{ ansible_hostname }}$'
-        line: 127.0.1.1 {{ ansible_hostname }}.{{ domain }} {{ ansible_hostname }}
+        regexp: '^127\.0\.1\.1'
+        line: ""


### PR DESCRIPTION
Let pre-requisites define the right hostname

<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes None

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

Remove hostname definition from `/etc/hosts`.

Let the hostname befined later from prerequisites.

Because of this line, zookeeper binds on the loopback interface.
Same for the journalnode quorum.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


