### PR TITLE
feat: add VM for tdp manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.vagrant/
+venv/
+pythonenv/
+.vscode/
+*.log
+.cache

--- a/README.md
+++ b/README.md
@@ -20,9 +20,21 @@ This is the default provider, no plugin needed.
 
 Follow documentation to install it https://vagrant-libvirt.github.io/vagrant-libvirt/.
 
-## Launch cluster
+## Setup python environment
 
 ```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Launch cluster
+
+If the `tdp_manager_enabled` flag in the vagrant.yml file is set to true, vagrant will provision a virtual machine for the TDP Manager, which is responsible for deploying the [tdp-getting-started](https://github.com/TOSIT-IO/tdp-getting-started) cluster.
+
+```bash
+# Activate Python virtual env
+source ./venv/bin/activate
 # With default virtualbox provider
 vagrant up
 # With libvirt provider
@@ -38,12 +50,138 @@ vagrant up
 
 **Important:** The Vagrantfile create an internal network so you must not run Vagrant in parallel because the internal network can be created multiple times leading to undefined behavior. With the Libvirt provider, VMs are launch in parallel so, if you want speed, use Libvirt provider.
 
+## TDP Quick Start
+
+If the `tdp_manager_enabled` flag is set to true, follow these steps:
+
+### TDP Prerequisites
+```bash
+# Connect to tdp-manager
+vagrant ssh tdp-manager
+# Move into project dir
+cd /opt/tdp/tdp-getting-started
+# Activate Python virtual env and set environment variables
+source ./venv/bin/activate && source .env
+# Configure TDP prerequisites
+ansible-playbook ansible_collections/tosit/tdp_prerequisites/playbooks/all.yml
+```
+
+## Deploy TDP 
+You have multiple options to deploy a TDP cluster:
+### Option 1: Deploy with TDP UI
+
+Access the TDP UI at http://localhost:3000/ on your local machine.
+
+- In the UI, go to "Deployments".
+- Select "New deployment", "Deploy from the DAG", and "Preview" (by default all services are deployed).
+- Click "Deploy."
+
+You can see the deployment in the "Deployments" page. Wait deployment to complete.
+
+### Option 2: Deploy with TDP server API
+
+You can access the TDP server at http://localhost:8000/ on your local machine.
+
+Run the following command to deploy TDP:
+
+```bash
+# Deploy TDP cluster core and extras services
+curl -X POST http://localhost:8000/api/v1/deploy/dag
+```
+
+To check the deployment status:
+
+```bash
+# run in your local machine
+while ! curl -s http://localhost:8000/api/v1/deploy/status | grep -q "no deployment on-going"; do sleep 10; done
+# Connect to tdp-manager
+vagrant ssh tdp-manager
+# Check deployment logs
+sudo journalctl -u tdp-server.service -f
+# Wait for deployment to complete
+```
+
+### Option 3: Deploy with TDP lib CLI
+
+```bash
+# Connect to tdp-manager
+vagrant ssh tdp-manager
+# Move into project dir
+cd /opt/tdp/tdp-getting-started
+# Activate Python virtual env and set environment variables
+source ./venv/bin/activate && source .env
+# Deploy TDP cluster core and extras services
+tdp deploy
+```
+
+### Option 4: Deploy with Ansible Playbook
+
+```bash
+# Connect to tdp-manager
+vagrant ssh tdp-manager
+# Move into project dir
+cd /opt/tdp/tdp-getting-started
+# Activate Python virtual env and set environment variables
+source ./venv/bin/activate && source .env
+# Deploy TDP cluster core services
+ansible-playbook ansible_collections/tosit/tdp/playbooks/meta/all.yml
+# Deploy extras services
+ansible-playbook ansible_collections/tosit/tdp_extra/playbooks/meta/livy.yml
+ansible-playbook ansible_collections/tosit/tdp_extra/playbooks/meta/livy-spark3.yml
+ansible-playbook ansible_collections/tosit/tdp_extra/playbooks/meta/zookeeper-kafka.yml
+ansible-playbook ansible_collections/tosit/tdp_extra/playbooks/meta/kafka.yml
+# Deploy observability services
+ansible-playbook ansible_collections/tosit/tdp_observability/playbooks/meta/prometheus.yml
+ansible-playbook ansible_collections/tosit/tdp_observability/playbooks/meta/grafana.yml
+```
+## Post-Installation
+
+After deploying the TDP cluster, perform the following post-installation tasks:
+
+```bash
+# Connect to tdp-manager
+vagrant ssh tdp-manager
+# Move into project dir
+cd /opt/tdp/tdp-getting-started
+# Activate Python virtual env and set environment variables
+source ./venv/bin/activate && source .env
+# Configure HDFS user home directories
+ansible-playbook ansible_collections/tosit/tdp/playbooks/utils/hdfs_user_homes.yml
+# Configure Ranger policies
+ansible-playbook ansible_collections/tosit/tdp/playbooks/utils/ranger_policies.yml
+```
+
 ## Connect to machine
 
 ```bash
 # Connect to edge
 vagrant ssh edge-01
 ```
+
+## Web UIs Links
+
+- [HDFS NN Master 01](https://master-01.tdp:9871/dfshealth.html)
+- [HDFS NN Master 02](https://master-02.tdp:9871/dfshealth.html)
+- [YARN RM Master 01](https://master-01.tdp:8090/cluster/apps)
+- [YARN RM Master 02](https://master-02.tdp:8090/cluster/apps)
+- [MapReduce Job History Server](https://master-03.tdp:19890/jobhistory)
+- [HBase Master 01](https://master-01.tdp:16010/master-status)
+- [HBase Master 02](https://master-02.tdp:16010/master-status)
+- [Spark History Server](https://master-03.tdp:18081/)
+- [Spark3 History Server](https://master-03.tdp:18083/)
+- [Ranger Admin](https://master-03.tdp:6182/index.html)
+- [JupyterHub](https://master-03.tdp:8000/)
+
+**Note:** All the WebUIs are Kerberized, you need to have a working Kerberos client on your host, configure the KDC in your `/etc/krb5.conf` file and obtain a valid ticket. 
+You can also access the WebUIs through Knox:
+
+- [HDFS NN](https://edge-01.tdp:8443/gateway/tdpldap/hdfs)
+- [YARN RM](https://edge-01.tdp:8443/gateway/tdpldap/yarn)
+- [MapReduce Job History Server](https://edge-01.tdp:8443/gateway/tdpldap/jobhistory)
+- [HBase Master](https://edge-01.tdp:8443/gateway/tdpldap/hbase/webui/master/master-status?host=master-01.tdp&port=16010)
+- [Spark History Server](https://edge-01.tdp:8443/gateway/tdpldap/sparkhistory)
+- [Spark3 History Server](https://edge-01.tdp:8443/gateway/tdpldap/spark3history)
+- [Ranger Admin](https://edge-01.tdp:8443/gateway/tdpldap/ranger)
 
 ## Destroy cluster
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,11 +17,11 @@ def destructure_host_dict(dict)
   dict.values_at("ip", "hostname", "cpus", "memory", "box")
 end
 
-
 domain = settings["domain"]
+all_hosts = settings["tdp_manager_enabled"] ? (settings["hosts"] + settings["tdp_manager_host"]) : settings["hosts"]
 
 # define groups and hostvars for ansible provisionner
-ansible_configuration = settings["hosts"].each_with_object({"hostvars": {}, "groups": Hash.new {|hash, key| hash[key] = []}}) do |host, configuration|
+ansible_configuration = all_hosts.each_with_object({"hostvars": {}, "groups": Hash.new {|hash, key| hash[key] = []}}) do |host, configuration|
   ip, hostname, cpus, memory, box = destructure_host_dict(host)
   configuration[:hostvars][hostname] = {
     :ip     => ip,
@@ -36,7 +36,7 @@ end # end configuration
 Vagrant.configure("2") do |config|
   config.vm.synced_folder "./", "/vagrant", disabled: true
 
-  settings["hosts"].each do |host|
+  all_hosts.each do |host|
     ip, hostname, cpus, memory, box = destructure_host_dict(host)
     box ||= settings["box"]
     config.vm.define hostname, autostart: true do |cfg|
@@ -47,19 +47,32 @@ Vagrant.configure("2") do |config|
       cfg.vm.provider :virtualbox do |vb|
         vb.name = hostname # sets gui name for VM
         vb.customize ["modifyvm", :id, "--memory", memory, "--cpus", cpus, "--hwvirtex", "on"]
+        # Forward TDP UI and server port
+        if hostname == "tdp-manager" && settings["tdp_manager_enabled"]
+          cfg.vm.network "forwarded_port", guest: 3000, host: 3000, id: 'tdp-ui'
+          cfg.vm.network "forwarded_port", guest: 8000, host: 8000, id: 'tdp-server'
+        end # end if 
+
       end # end provider virtualbox
 
       cfg.vm.provider :libvirt do |libvirt|
         libvirt.cpus = cpus
         libvirt.memory = memory
         libvirt.qemu_use_session = false
+        # Forward TDP UI and server port
+        if hostname == "tdp-manager" && settings["tdp_manager_enabled"]
+          cfg.vm.network "forwarded_port", guest: 3000, host: 3000, id: 'tdp-ui'
+          cfg.vm.network "forwarded_port", guest: 8000, host: 8000, id: 'tdp-server'
+        end # end if 
       end # end provider libvirt
     end # end define
   end # end settings
 
   config.vm.provision :ansible do |ansible|
-    ansible.playbook = "#{vagrantfile_dir}/provision.yml"
+    ansible.playbook = "#{vagrantfile_dir}/provision/main.yml"
     ansible.host_vars = ansible_configuration[:hostvars]
     ansible.groups = ansible_configuration[:groups]
+    ansible.extra_vars = {tdp_manager_enabled: settings["tdp_manager_enabled"]}
+    ansible.config_file = "#{vagrantfile_dir}/ansible.cfg"
   end # end provision
 end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,11 @@
+[defaults]
+host_key_checking = False
+log_path = logs/ansible.log
+hash_behaviour = merge
+stdout_callback = yaml
+
+[inventory]
+cache = true
+cache_plugin = jsonfile
+cache_timeout = 7200
+cache_connection = .cache

--- a/provision.yml
+++ b/provision.yml
@@ -1,9 +1,0 @@
----
-- hosts: all
-  become: yes
-  tasks:
-    - name: Remove hostname configuration on loopback interface
-      lineinfile:
-        path: /etc/hosts
-        regexp: '^127\.0\.1\.1'
-        line: ""

--- a/provision/main.yml
+++ b/provision/main.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Remove hostname configuration on loopback interface
+  hosts: all
+  become: yes
+  roles:
+    - name: common
+
+- name: Setup TDP manger
+  hosts: tdp-manager
+  roles:
+    - name: tdp-manager
+      when: tdp_manager_enabled

--- a/provision/roles/common/tasks/main.yml
+++ b/provision/roles/common/tasks/main.yml
@@ -1,0 +1,8 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Remove hostname configuration on loopback interface
+  lineinfile:
+    path: /etc/hosts
+    regexp: '^127\.0\.1\.1'
+    line: ""

--- a/provision/roles/tdp-manager/defaults/main.yml
+++ b/provision/roles/tdp-manager/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+project_dir: /opt/tdp/tdp-getting-started
+git_project_url: https://github.com/TOSIT-IO/tdp-getting-started.git
+git_project_version: 0.1
+python_bin: python3.6
+features_version: stable
+features:
+  - server
+  - ui
+  - prerequisites
+  - extras
+  # - observability

--- a/provision/roles/tdp-manager/tasks/git.yml
+++ b/provision/roles/tdp-manager/tasks/git.yml
@@ -1,0 +1,18 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Ensure {{ project_dir }} exists
+  become: true
+  file:
+    path: "{{ project_dir }}"
+    state: directory
+    owner: vagrant
+    group: vagrant
+
+- name: Clone {{ git_project_url }}
+  git:
+    repo: "{{ git_project_url }}"
+    dest: "{{ project_dir }}"
+    version: "{{ git_project_version }}"
+    recursive: false
+    force: true

--- a/provision/roles/tdp-manager/tasks/inventory.yml
+++ b/provision/roles/tdp-manager/tasks/inventory.yml
@@ -1,0 +1,39 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Copy inventory files
+  copy: 
+    src:  "{{ playbook_dir }}/../.vagrant"
+    dest: "{{ project_dir }}"
+    mode: "600"
+
+- name: Template hosts.ini file
+  template:
+    src: inventory.j2
+    dest: "{{ project_dir }}/inventory/hosts.ini"
+
+- name: Create list from inventory
+  set_fact:
+    etc_hosts_inventory_block: |-
+      {% for host, vars in hostvars.items() -%}
+      {% if 'ip' in vars -%}
+      {{ vars['ip'] }}
+      {%- if ('ansible_hostname' in vars and host != vars['ansible_hostname']) %} {{ vars['ansible_hostname'] }}.{{ domain }} {{ vars['ansible_hostname'] }}.{{ domain }}. {{ vars['ansible_hostname'] }}{% endif %} {{ host }}.{{ domain }} {{ host }}.{{ domain }}. {{ host }}
+      {% endif %}
+      {% endfor %}
+  delegate_to: localhost
+  connection: local
+  delegate_facts: true
+  run_once: true
+
+- name: Populate inventory into hosts file
+  become: true
+  blockinfile:
+    path: /etc/hosts
+    block: "{{ hostvars.localhost.etc_hosts_inventory_block }}"
+    state: present
+    create: yes
+    backup: yes
+    unsafe_writes: yes
+    marker: "# Ansible inventory hosts {mark}"
+

--- a/provision/roles/tdp-manager/tasks/main.yml
+++ b/provision/roles/tdp-manager/tasks/main.yml
@@ -1,0 +1,16 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- import_tasks: system.yml
+
+- import_tasks: git.yml
+
+- import_tasks: setup.yml
+
+- import_tasks: inventory.yml
+
+- import_tasks: tdp-server.yml
+  when: "'server' in features"
+
+- import_tasks: tdp-ui.yml
+  when: "'ui' in features"

--- a/provision/roles/tdp-manager/tasks/setup.yml
+++ b/provision/roles/tdp-manager/tasks/setup.yml
@@ -1,0 +1,17 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Launch setup.sh script
+  shell: |
+    export PYTHON_BIN="{{ python_bin }}"
+    ./scripts/setup.sh -e {{ features | join(' -e ') }} -r {{ features_version }}
+  args:
+    chdir: "{{ project_dir }}"
+
+- name: Setup collection observability
+  shell: |
+    source ./venv/bin/activate && source ./.env
+    ./ansible_collections/tosit/tdp_observability/scripts/setup.sh -c
+  args:
+    chdir: "{{ project_dir }}"
+  when: "'observability' in features"

--- a/provision/roles/tdp-manager/tasks/system.yml
+++ b/provision/roles/tdp-manager/tasks/system.yml
@@ -1,0 +1,47 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Install system requirements
+  become: true
+  yum:
+    name:
+      - git
+      - unzip
+      - python39
+      - jq
+    state: present
+
+- name: Ensure {{ python_bin }} pip is up to date
+  become: true
+  pip:
+    name: pip
+    executable: pip3
+    state: latest
+
+- name: Remove existing nodejs
+  become: yes
+  yum:
+    name: nodejs
+    state: absent
+  when: "'ui' in features"
+
+- name: Install Node.js v18.x
+  become: true
+  shell: |
+    yum install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y &&
+    yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
+  when: "'ui' in features"
+
+- name: Check if firewalld is installed
+  become: true
+  yum:
+    list: installed
+  register: yum_installed
+
+- name: Stop and disable firewalld
+  become: true
+  service:
+    name: firewalld
+    state: stopped
+    enabled: no
+  when: "'firewalld' in (yum_installed.results | map(attribute='name'))"

--- a/provision/roles/tdp-manager/tasks/system.yml
+++ b/provision/roles/tdp-manager/tasks/system.yml
@@ -19,17 +19,37 @@
     state: latest
 
 - name: Remove existing nodejs
-  become: yes
+  become: true
   yum:
     name: nodejs
     state: absent
   when: "'ui' in features"
 
-- name: Install Node.js v18.x
+- name: Download Node.js package
   become: true
-  shell: |
-    yum install https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y &&
-    yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
+  get_url:
+    url: https://nodejs.org/dist/v18.18.1/node-v18.18.1-linux-x64.tar.xz
+    dest: /tmp/node-v18.18.1-linux-x64.tar.xz
+  when: "'ui' in features"
+
+- name: Extract Node.js package
+  become: true
+  unarchive:
+    src: /tmp/node-v18.18.1-linux-x64.tar.xz
+    dest: /opt
+    remote_src: true
+  when: "'ui' in features"
+
+- name: Create symlink for /usr/bin/node, /usr/bin/npm, and /usr/bin/npx
+  become: true
+  file:
+    src: "/opt/node-v18.18.1-linux-x64/bin/{{ item }}"
+    dest: "/usr/bin/{{ item }}"
+    state: link
+  loop:
+    - node
+    - npm
+    - npx
   when: "'ui' in features"
 
 - name: Check if firewalld is installed

--- a/provision/roles/tdp-manager/tasks/tdp-server.yml
+++ b/provision/roles/tdp-manager/tasks/tdp-server.yml
@@ -1,0 +1,34 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Copy environment file to /etc/sysconfig/tdp-server
+  become: true
+  copy:
+    src: "{{ project_dir }}/.env"
+    dest: /etc/sysconfig/tdp-server
+    remote_src: yes
+    owner: root
+    group: root
+    mode: '0644'
+  register: copy_result
+
+- name: Remove 'export ' from /etc/sysconfig/tdp-server
+  become: true
+  replace:
+    path: /etc/sysconfig/tdp-server
+    regexp: '^export '
+    replace: ''
+  when: copy_result.changed
+
+- name: Template TDP server service file
+  become: true
+  template:
+    src: tdp-server.service.j2
+    dest: /usr/lib/systemd/system/tdp-server.service
+
+- name: Start TDP server service
+  become: true
+  systemd:
+    name: tdp-server.service
+    state: started
+    enabled: yes

--- a/provision/roles/tdp-manager/tasks/tdp-ui.yml
+++ b/provision/roles/tdp-manager/tasks/tdp-ui.yml
@@ -1,0 +1,15 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Template TDP UI service file
+  become: true
+  template:
+    src: tdp-ui.service.j2
+    dest: /usr/lib/systemd/system/tdp-ui.service
+
+- name: Start TDP UI service
+  become: true
+  systemd:
+    name: tdp-ui.service
+    state: started
+    enabled: yes

--- a/provision/roles/tdp-manager/templates/inventory.j2
+++ b/provision/roles/tdp-manager/templates/inventory.j2
@@ -1,0 +1,19 @@
+{% set exclude_group = 'tdp-manager' %}
+
+{% for host, vars in hostvars.items() %}
+{% if host not in groups[exclude_group] %}
+{{ host }} ansible_ssh_user='vagrant' ansible_ssh_private_key_file='{{ project_dir }}/.vagrant/machines/{{ host }}/virtualbox/private_key' ip={{ vars.ip }} domain={{ vars.domain }}
+{% endif %}
+{% endfor %}
+
+{% for group in groups %}
+{% if group != exclude_group %}
+[{{ group }}]
+{% for host in groups[group] %}
+{% if host not in groups[exclude_group] %}
+{{ host }}
+{% endif %}
+{% endfor %}
+
+{% endif %}
+{% endfor %}

--- a/provision/roles/tdp-manager/templates/tdp-server.service.j2
+++ b/provision/roles/tdp-manager/templates/tdp-server.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=TDP server
+
+[Service]
+User=vagrant
+WorkingDirectory={{ project_dir }}
+EnvironmentFile=/etc/sysconfig/tdp-server
+Environment=PATH={{ project_dir }}/venv/bin:/home/vagrant/.local/bin:/home/vagrant/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
+# Workaround to fix https://github.com/TOSIT-IO/tdp-collection/issues/781
+Environment=PWD=.
+Type=simple
+ExecStart={{ project_dir }}/venv/bin/uvicorn tdp_server.main:app --reload --host 0.0.0.0
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/provision/roles/tdp-manager/templates/tdp-ui.service.j2
+++ b/provision/roles/tdp-manager/templates/tdp-ui.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=TDP UI
+After=tdp-server.service
+
+[Service]
+User=vagrant
+WorkingDirectory={{ project_dir }}
+Type=simple
+ExecStart=npm --prefix ./tdp-ui run dev
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -2,6 +2,9 @@
 # Run "vagrant reload" when box is modified
 box: generic/rocky8
 
+# Add VM for TDP Manager
+tdp_manager_enabled: true
+
 # network domain
 domain: tdp
 
@@ -51,4 +54,12 @@ hosts:
       - worker
     hostname: worker-03
     ip: 192.168.56.16
+    memory: 2048
+
+tdp_manager_host:
+  - cpus: 2
+    groups:
+      -  tdp-manager
+    hostname: tdp-manager
+    ip: 192.168.56.17
     memory: 2048


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #23 

#### Additional comments:
Add a VM TDP manager when the tdp_manager_enabled flag is set to true in the vagrant.yml. 
It will create a virtual machine for the TDP Manager, set up necessary system prerequisites, clone the TDP Getting Started repository, run the setup script, and create systemd services for the TDP server and TDP UI. These services will be automatically accessible from the user's localhost.

Note that the master branch of tdp-vagrant uses the generic/rocky8 box. When testing this with collections tag 0.1, the commit https://github.com/TOSIT-IO/tdp-collection-prerequisites/pull/88 has not been introduced yet. To address this, you'll need to manually add the commit by running `git cherry-pick 7327790` in the tdp_prerequisites folder.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


