### PR TITLE
refactor: added 2GB to master-03 memory

### DIFF
--- a/vagrant.yml
+++ b/vagrant.yml
@@ -33,7 +33,7 @@ hosts:
       - master3
     hostname: master-03
     ip: 192.168.56.13
-    memory: 3072
+    memory: 5120
   - cpus: 2
     groups:
       - worker


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes  None

#### Additional comments:

2GB of memory have been added to the master-03 node which contains Spark2 and Spark3 History_Server, HBase_Phoenix_Queryserver, HBase_Rest, Yarn_Mapreduce_History_Server, Yarn_Timeline_Server, Hive_Metastore, Hive_Server2, HDFS_Journal_Node, Ranger, Jupyter, Zookeeper.

The cluster in total takes 19GB of memory instead of 17GB before. However, it is still not enough looking at the memory used by all services (Heap size of HDFS, HBase ...etc. have been reduced in TDP-dev compared to a production deployment) but the cluster must fit in a machine of 32GB of RAM.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


